### PR TITLE
Last minute fixes

### DIFF
--- a/undeRaspino/undeRasp_v2a/defines.h
+++ b/undeRaspino/undeRasp_v2a/defines.h
@@ -19,6 +19,8 @@ typedef uint32_t time_t;
 
 #endif
 
+#define DIRECT_ADC 1
+
 // Function to use program memory for strings
 #define PS(str) (strcpy_P(prog_buf, PSTR(str)), prog_buf)
 extern char prog_buf[100]; // initialized in utils.h

--- a/undeRaspino/undeRasp_v2a/undeRasp_v2a.ino
+++ b/undeRaspino/undeRasp_v2a/undeRasp_v2a.ino
@@ -231,6 +231,11 @@ void setup() {
    digitalWrite(MOSFET_PIN, 0);
    digitalWrite(SERIAL_ARDUINO_PIN, 1);
 
+   // Ensure RPI shutdown
+   digitalWrite(RELAY_RESET_PIN, 1);
+   delay(20);
+   digitalWrite(RELAY_RESET_PIN, 0);
+
 #if BB_DEBUG
    pinMode(DBG_PIN, OUTPUT);
    digitalWrite(DBG_PIN, 0);

--- a/undeRaspino/undeRasp_v2a/undeRasp_v2a.ino
+++ b/undeRaspino/undeRasp_v2a/undeRasp_v2a.ino
@@ -307,6 +307,18 @@ void setup() {
    TCCR2A = 0; // set entire TCCR2A register to 0
    TCCR2B = 0; // same for TCCR2B
    TCNT2 = 0;  // initialize counter value to 0
+
+#if F_CPU == 16000000L
+   // set compare match register for 2000 Hz increments (TIMER 2 does not play
+   // well 64 bit prescaler)
+   OCR2A = 249; // = 16000000 / (32 * 2000) - 1 (must be <256)
+   // turn on CTC mode
+   TCCR2B |= (1 << WGM21);
+   // Set CS22, CS21 and CS20 bits for 32 prescaler
+   TCCR2B |= (0 << CS22) | (1 << CS21) | (1 << CS20);
+   // enable timer compare interrupt
+   TIMSK2 |= (1 << OCIE2A);
+#else
    // set compare match register for 1000 Hz increments
    OCR2A = 249; // = 8000000 / (32 * 1000) - 1 (must be <256)
    // OCR2A = (unsigned short int)(F_CPU / (32 * 1000) - 1);
@@ -316,6 +328,7 @@ void setup() {
    TCCR2B |= (0 << CS22) | (1 << CS21) | (1 << CS20);
    // enable timer compare interrupt
    TIMSK2 |= (1 << OCIE2A);
+#endif
 
    sei(); // allow interrupts
 
@@ -380,7 +393,15 @@ void loop() {
    rpi_handle_ops();
 }
 
+bool even = false;
 ISR(TIMER2_COMPA_vect) {
+#if F_CPU == 16000000L
+   if (!even) {
+      even = true;
+      return;
+   }
+   even = false;
+#endif
    update_samples();
    update_led_timer();
 }

--- a/undeRaspino/undeRasp_v2a/undeRasp_v2a.ino
+++ b/undeRaspino/undeRasp_v2a/undeRasp_v2a.ino
@@ -275,6 +275,7 @@ void setup() {
    print_menu();
 
    rpi_setup();
+   adc_setup();
 
    cli(); // stop interrupts
 

--- a/undeRaspino/undeRasp_v2a/utils.cpp
+++ b/undeRaspino/undeRasp_v2a/utils.cpp
@@ -12,6 +12,7 @@ unsigned int led_timer = 0;
 int voltage_samples[SAMPLES_SIZE];
 int ampere_samples[SAMPLES_SIZE];
 int samples_pos = 0;
+bool is_reading_temp = false;
 
 bool atoi(char *in, int *out, char *err) {
    int i;
@@ -258,6 +259,7 @@ double get_ampere() {
 double get_watts() { return get_voltage() * get_ampere(); }
 
 double get_temperature() {
+   is_reading_temp = true;
    unsigned int wADC;
    double t;
    ADMUX = (_BV(REFS1) | _BV(REFS0) | _BV(MUX3));
@@ -268,10 +270,13 @@ double get_temperature() {
       ;
    wADC = ADCW;
    t = (wADC - 324.31) / 1.22;
+   is_reading_temp = false;
    return abs(t);
 }
 
 void update_samples() {
+   if (is_reading_temp)
+      return; // we cannot perform analogReads when reading temperature
    voltage_samples[samples_pos] = analogRead(VOLTAGE_PIN);
    ampere_samples[samples_pos] = analogRead(AMPERE_PIN);
    samples_pos += 1;

--- a/undeRaspino/undeRasp_v2a/utils.cpp
+++ b/undeRaspino/undeRasp_v2a/utils.cpp
@@ -40,7 +40,9 @@ bool atod(char *in, char *data, char *err) {
 }
 
 void set_error(uint8_t errcode, const char *msg) {
+#if DEBUG
    Serial.println(msg);
+#endif
    error_status = true;
    EEPROM.write(EEPROM_ERROR, errcode);
    set_led_status(LED_ERROR);

--- a/undeRaspino/undeRasp_v2a/utils.h
+++ b/undeRaspino/undeRasp_v2a/utils.h
@@ -37,6 +37,7 @@ void set_led_status(unsigned short int mode);
 void update_samples();
 void update_led_timer();
 
+void adc_setup();
 
 extern RTC_DS1307 RTC;
 #endif


### PR DESCRIPTION
- Always shut down RPI on boot
- Do not print error messages if not in debug mode
- Do not sample volts and current when reading temperature
  (analogRead in sampling interrupt seems to screw up the temperature readings)